### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 main.py"

--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ Prediction:
 Roadmap:
 * Try Telegram PIP Modules
 * Hook it up with Errors
+
+
+[![Run on Repl.it](https://repl.it/badge/github/Jochnickel/telegram_bot_rpg)](https://repl.it/github/Jochnickel/telegram_bot_rpg)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).